### PR TITLE
This case was invalid

### DIFF
--- a/src/main/scala/io/sphere/JsonSchemaInliner.scala
+++ b/src/main/scala/io/sphere/JsonSchemaInliner.scala
@@ -46,11 +46,6 @@ class JsonSchemaInliner(source: File, streams: TaskStreams) {
     json.transform {
       case JObject(JField("$ref", JString(file: String)) :: List()) if !inlinedFiles.contains(file) =>
         raj.get(file).map(inlineSchema(_, raj, inlinedFiles :+ file)).getOrElse(JObject(List(JField("$ref", JString(file)))))
-      case JObject(JField("$ref", JString(file: String)) :: otherFields) if !inlinedFiles.contains(file) =>
-        raj.get(file).map(inlineSchema(_, raj, inlinedFiles :+ file)).map {
-          case JObject(fields) => JObject(fields ::: otherFields)
-          case o => o
-        }.getOrElse(JObject(List(JField("$ref", JString(file)))))
     }
   }
 


### PR DESCRIPTION
After reading up on it [0], having more fields than `$ref` inside the Object is invalid. I'll have to check whether we are still using `$ref` like this anywhere. I think @agourlay used it like this and that's why I added it to the inliner originally.

[0] http://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03#section-3
